### PR TITLE
FIX: duplicate slash in breadcrumbs when trailingslash is activated

### DIFF
--- a/resources/views/Other/Breadcrumbs.twig
+++ b/resources/views/Other/Breadcrumbs.twig
@@ -24,8 +24,11 @@
 
                 {% for category in blogCategoryBreadcrumbs %}
                     {% if not loop.last %}
-
-                        {% set blogCategoryUrl = blogCategoryUrl ~ "/" ~ category.details[0].nameUrl ~ urls.trailingSlashSuffix %}
+                        {% if not (blogCategoryUrl ends with '/') %}
+                            {% set blogCategoryUrl = blogCategoryUrl ~ "/" ~ category.details[0].nameUrl ~ urls.trailingSlashSuffix %}
+                        {% else %}
+                            {% set blogCategoryUrl = blogCategoryUrl ~ category.details[0].nameUrl ~ urls.trailingSlashSuffix %}
+                        {% endif %}
                         <li class="breadcrumb-item">
                             <a href="{{ blogCategoryUrl }}">{{ category.details[0].name }}</a>
                         </li>


### PR DESCRIPTION
@Dominik2809 
